### PR TITLE
another bugfix for client-side widget inheritance

### DIFF
--- a/lib/feather-client/widget.js
+++ b/lib/feather-client/widget.js
@@ -429,7 +429,7 @@
                 }), function(err) {
                   if (err) callback(err); else {
                     //get the declaratively defined html for the widget if there is any
-                    instance.contentTemplate = el.children("contentTemplate");
+                    instance.contentTemplate = instance.contentTemplate || el.children("contentTemplate");
 
                     //remove the widget node from the current parent and replace with an appropriate container
                     //TODO: move this into an instance method that can be overridden for custom container wrapping  


### PR DESCRIPTION
don't overwrite contentTemplate if it has been explicitly declared already
