### PR TITLE
invasive doctype fix (see TODO note)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -111,6 +111,9 @@ var parseFile = exports.parseFile = function(options, cb) {
                     //final replaces: if sending custom tags to the client, namespace them (required for IE)                    
                     _html = _html.replace(widgetTagFixRegex, "<$1feather:widget");
                     _html = _html.replace(optionsTagFixRegex, "<$1feather:options");
+
+                    //TODO: find non-invasive way to do this that allows overriding
+                    _html = "<!doctype html>\n" + _html;
                                
                     //create a render function to return to the main callback 
                     //TODO: make _cb signature be in node's error-first callback style


### PR DESCRIPTION
force <!doctype html> (get IE to render in standards mode by default vs. quirks mode)
