### PR TITLE
SSL and data

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -290,6 +290,9 @@ dataInterface.prototype = {
         cb && cb(formatError(err));
 
       } else {
+        if (options.returnValuesOnly) {
+          documents = _.pluck(documents, "value");
+        }
         if (prefetchBoundaries === true) {
           pagination.pageBoundaries = [];
           var index = 0;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -109,13 +109,21 @@ var init = socket.init = function(options, cb) {
       //create a shim http server instance
       var shimServer;
       if (options.ssl && options.ssl.enabled) {
-        shimServer = https.createServer({
+        var tlsOptions = {
           key: fs.readFileSync(options.ssl.key),
           cert: fs.readFileSync(options.ssl.cert)
-        }, function(req, res) {
+        };
+        if (options.ssl.ca) {
+          tlsOptions.ca = [];
+          _.each(options.ssl.ca, function(ca) {
+            var certs = fs.readFileSync(ca);
+            tlsOptions.ca.push(certs);
+          });
+        }
+        shimServer = https.createServer(tlsOptions, function(req, res) {
           //TODO: anything needed here?
         });
-      } else {
+      } else { // Non-SSL
         shimServer = http.createServer(function(req, res) {
           //TODO: anything needed here?
         });


### PR DESCRIPTION
Small data tweak.  find function now accepts "returnValuesOnly" option that plucks the "value" property out of view results before returning it for the case where you only want full docs back.

Fixed SSL ca certs on socket server.
