### PR TITLE
Widget data linking fix to allow radio buttons to work.

### DIFF
--- a/lib/feather-client/widget.js
+++ b/lib/feather-client/widget.js
@@ -184,7 +184,11 @@
           $(form).link(me.model[datalink], options);
           for (var p in me.model[datalink]) {
             $("[name=" + p + "]", form).each(function(index, field) {
-              $(field).val(me.model[datalink][p]);
+              if ($(field).attr('type') !== "radio") {
+                $(field).val(me.model[datalink][p]);
+              } else if (me.model[datalink][p] === $(field).val()) {
+                $(field).attr('checked', "checked");
+              }
             });
           }
         }


### PR DESCRIPTION
Radio buttons shouldn't have their value changed via data linking. Instead, if the data source has the same value, then the 'checked' attribute now gets added to the element.
