### PR TITLE
some general ui stuff and tweak for bootstrap dialogs

### DIFF
--- a/lib/feather-client/ui-bootstrap.js
+++ b/lib/feather-client/ui-bootstrap.js
@@ -127,13 +127,18 @@
         dialog.onceState("ready", function() {
           widget.container = dialog.get('.modal-body');
           widget.setParent(dialog);
-        });              
-        //wrap the dispose method to destroy the dialog
-        widget.on("disposed", function() {
-          if (!dialog.disposing) {
-            dialog.dispose && dialog.dispose();
+        });         
+
+        //invert the widget's dispose method to call the dialog's first (gracefully close the dialog w/ animations if present)
+        var _dispose = _.bind(widget.dispose, widget);
+        widget.dispose = function() {
+          if (dialog.disposing) {
+            _dispose();
+          } else {
+            dialog.close(true);
           }
-        });
+        };
+
         dialog.render();
       }    
     }

--- a/lib/resource-packager.js
+++ b/lib/resource-packager.js
@@ -159,113 +159,143 @@ exports.packageResources = function(options, callback) {
  * @param {Object} options
  */
 exports.packageFrameworkResources = function(options, callback) {
-  
-  var prefix = options.appOptions.featherRoot;
+  simpleCache.getItem('feather-files', function(err, featherFiles) {
+    var prefix = options.appOptions.featherRoot;
+    
+    var cssFiles = [];
 
-  var cssFiles = [];
+    //TODO: this ultimately needs to change somehow to prevent cross-protocol serving of socket.io resources (IE9 complains)
+    if (options.appOptions["socket.io"].enabled) {
+      var socketProtocol = options.appOptions.ssl && options.appOptions.ssl.enabled ? "https" : "http";
+      var socketPrefix = socketProtocol + "://" + options.appOptions["socket.io"].host + ":" + options.appOptions["socket.io"].port;
+    }
+    
+    // js -----------------------------------------------------------------
+    var jsFiles = [
+      {path: "/feather-client/lib/underscore-min.js", prefix: prefix},
+      options.appOptions["socket.io"].enabled ? {path: socketPrefix + "/socket.io/socket.io.js", prefix: prefix, virtual: true} : null,
+      {path: "/feather-client/lib/json2.js", prefix: prefix, minifyAllowed: false},
+      {path: "/feather-client/lib/jquery-1.7.min.js", prefix: prefix},
+      {path: "/feather-client/lib/jquery.tmpl.js", prefix: prefix},
+      {path: "/feather-client/lib/jquery.cookie.js", prefix: prefix},
+      {path: "/feather-client/lib/inherits.js", prefix: prefix},
+      {path: "/feather-client/feather.js", prefix: prefix},
+      {path: "/feather-client/base-class.js", prefix: prefix},
+      {path: "/feather-client/event-publisher.js", prefix: prefix},
+      {path: "/feather-client/dom-event-cache.js", prefix: prefix},
+      {path: "/feather-client/registry.js", prefix: prefix},
+      {path: "/feather-client/semaphore.js", prefix: prefix},
+      {path: "/feather-client/fsm.js", prefix: prefix},
+      {path: "/feather-client/util.js", prefix: prefix},
+      {path: "/feather-client/widget.js", prefix: prefix},
+      {path: "/feather-client/socket.js", prefix: prefix}
+    ];
 
-  //TODO: this ultimately needs to change somehow to prevent cross-protocol serving of socket.io resources (IE9 complains)
-  if (options.appOptions["socket.io"].enabled) {
-    var socketProtocol = options.appOptions.ssl && options.appOptions.ssl.enabled ? "https" : "http";
-    var socketPrefix = socketProtocol + "://" + options.appOptions["socket.io"].host + ":" + options.appOptions["socket.io"].port;
-  }
-  
-  // js -----------------------------------------------------------------
-  var jsFiles = [
-    {path: "/feather-client/lib/underscore-min.js", prefix: prefix},
-    options.appOptions["socket.io"].enabled ? {path: socketPrefix + "/socket.io/socket.io.js", prefix: prefix, virtual: true} : null,
-    {path: "/feather-client/lib/json2.js", prefix: prefix, minifyAllowed: false},
-    {path: "/feather-client/lib/jquery-1.7.min.js", prefix: prefix},
-    {path: "/feather-client/lib/jquery.tmpl.js", prefix: prefix},
-    {path: "/feather-client/lib/jquery.cookie.js", prefix: prefix},
-    {path: "/feather-client/lib/inherits.js", prefix: prefix},
-    {path: "/feather-client/feather.js", prefix: prefix},
-    {path: "/feather-client/base-class.js", prefix: prefix},
-    {path: "/feather-client/event-publisher.js", prefix: prefix},
-    {path: "/feather-client/dom-event-cache.js", prefix: prefix},
-    {path: "/feather-client/registry.js", prefix: prefix},
-    {path: "/feather-client/semaphore.js", prefix: prefix},
-    {path: "/feather-client/fsm.js", prefix: prefix},
-    {path: "/feather-client/util.js", prefix: prefix},
-    {path: "/feather-client/widget.js", prefix: prefix},
-    {path: "/feather-client/socket.js", prefix: prefix}
-  ];
+    if (options.appOptions.rest && options.appOptions.rest.autoGenerateProxy && options.restProxyInfo) {
+      //add the restProxy files
+      jsFiles.push({path: "/feather-client/restProxy.js", prefix: prefix});
+      jsFiles.push({
+        path: options.restProxyInfo.path,
+        prefix: options.restProxyInfo.prefix
+      });
+    }
+    
+    // Only add the auth scripts if this app has auth enabled.
+    if (options.appOptions.auth.enabled) {
+      //jsFiles.push({path: "feather-client/sha512.js", prefix: prefix});
+      jsFiles.push({path: "/feather-client/auth-client.js", prefix: prefix});
+    }
+    
+    // Add datalinking if enabled
+    if (options.appOptions.data.datalinking.enabled) {
+      jsFiles.push({path: "/feather-client/lib/jquery.datalink.js", prefix: prefix});
+    }
+    
+    // Add files for the ui provider if enabled
+    if (options.appOptions.ui.enabled) {    
+      var uiJSPrefix = prefix,
+        uiCSSPrefix = prefix,
+        provider = options.appOptions.ui.provider,
+        providers = options.appOptions.ui.providers;
 
-  if (options.appOptions.rest && options.appOptions.rest.autoGenerateProxy && options.restProxyInfo) {
-    //add the restProxy files
-    jsFiles.push({path: "/feather-client/restProxy.js", prefix: prefix});
-    jsFiles.push({
-      path: options.restProxyInfo.path,
-      prefix: options.restProxyInfo.prefix
-    });
-  }
-  
-  // Only add the auth scripts if this app has auth enabled.
-  if (options.appOptions.auth.enabled) {
-    //jsFiles.push({path: "feather-client/sha512.js", prefix: prefix});
-    jsFiles.push({path: "/feather-client/auth-client.js", prefix: prefix});
-  }
-  
-  // Add datalinking if enabled
-  if (options.appOptions.data.datalinking.enabled) {
-    jsFiles.push({path: "/feather-client/lib/jquery.datalink.js", prefix: prefix});
-  }
-  
-  // Add files for the ui provider if enabled
-  if (options.appOptions.ui.enabled) {
-    var uiJSPrefix = prefix,
-      uiCSSPrefix = prefix,
-      provider = options.appOptions.ui.provider,
-      providers = options.appOptions.ui.providers;
+      if (typeof provider === 'string') {
+        provider = _.find(providers, function(_provider) {
+          return _provider.name === provider;
+        });
+      }
 
-    if (typeof provider === 'string') {
-      provider = _.find(providers, function(_provider) {
-        return _provider.name === provider;
+      //get the js files
+      var appFiles = _.keys(featherFiles.appFiles);
+      if (provider.jsRoot === "/") uiJSPrefix = options.appOptions.publicRoot;
+      _.each(provider.jsFiles, function(file) {
+        var _path = file,
+          _prefix = uiJSPrefix;
+
+        //detect automatic app overrides (via dropping in new files in the /public/_ui folder)
+        var fileName = file.replace(/.*\/([^\/]*)$/, '$1');
+        var overrideFile = _.find(appFiles, function(_appFile) {
+          return _appFile.indexOf('/public/_ui/' + provider.name + '/js/' + fileName) > -1;
+        });
+
+        if (overrideFile) {
+          _prefix = options.appOptions.publicRoot;
+          _path = path.relative(options.appOptions.publicRoot, overrideFile);
+        }
+        
+        jsFiles.push({path: _path, prefix: _prefix});
+      });
+
+      //get the css files
+      if (provider.cssRoot === "/") uiCSSPrefix = options.appOptions.publicRoot;
+      _.each(provider.cssFiles, function(file) {
+        var _path = file,
+          _prefix = uiCSSPrefix;
+
+        //detect automatic app overrides (via dropping in new files in the /public/_ui folder)
+        var fileName = file.replace(/.*\/([^\/]*)$/, '$1');
+        var overrideFile = _.find(appFiles, function(_appFile) {
+          return _appFile.indexOf('/public/_ui/' + provider.name + '/css/' + fileName) > -1;
+        });
+
+        if (overrideFile) {
+          _prefix = options.appOptions.publicRoot;
+          _path = '/' + path.relative(options.appOptions.publicRoot, overrideFile);
+        }
+        
+        cssFiles.push({path: _path, prefix: _prefix});
       });
     }
 
-    //get the js files
-    if (provider.jsRoot === "/") uiJSPrefix = options.appOptions.publicRoot;
-    _.each(provider.jsFiles, function(file) {
-      jsFiles.push({path: file, prefix: uiJSPrefix});
+    var jsOptions = _.extend(_.clone(options), {
+      template: '<clientscript type="text/javascript" src="${href}"></clientscript>',
+      cacheName: "feather-client-core.js",
+      hrefPrefix: "",
+      contentType: "text/javascript",
+      files: _.compact(jsFiles)
     });
 
-    //get the css files
-    if (provider.cssRoot === "/") uiCSSPrefix = options.appOptions.publicRoot;
-    _.each(provider.cssFiles, function(file) {
-      cssFiles.push({path: file, prefix: uiCSSPrefix});
-    });
-  }
-
-  var jsOptions = _.extend(_.clone(options), {
-    template: '<clientscript type="text/javascript" src="${href}"></clientscript>',
-    cacheName: "feather-client-core.js",
-    hrefPrefix: "",
-    contentType: "text/javascript",
-    files: _.compact(jsFiles)
-  });
-
-  var frameworkPackaged = new Semaphore(callback);
-  
-  frameworkPackaged.increment();
-  exports.packageResources(jsOptions, function(err) {
-    frameworkPackaged.execute(err);
-  });
-  
-  if (cssFiles.length) {
-
-    var cssOptions = _.extend(_.clone(options), {
-      template: '<link rel="stylesheet" type="text/css" href="${href}" />',
-      cacheName: "feather-client-core.css",
-      contentType: "text/css",
-      files: cssFiles
-    });
-
+    var frameworkPackaged = new Semaphore(callback);
+    
     frameworkPackaged.increment();
-    exports.packageResources(cssOptions, function(err) {
+    exports.packageResources(jsOptions, function(err) {
       frameworkPackaged.execute(err);
     });
-  }
+    
+    if (cssFiles.length) {
+
+      var cssOptions = _.extend(_.clone(options), {
+        template: '<link rel="stylesheet" type="text/css" href="${href}" />',
+        cacheName: "feather-client-core.css",
+        contentType: "text/css",
+        files: cssFiles
+      });
+
+      frameworkPackaged.increment();
+      exports.packageResources(cssOptions, function(err) {
+        frameworkPackaged.execute(err);
+      });
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
ui provider override files can now be place in your app's /public/_ui folder (an implicit convention just added) and they will automatically be included instead of the given provider's base files.

Also, check prior recent commits... ui provider configuration semantics have changed a bit (see: https://github.com/theVolary/feather/blob/master/lib/config.json#L123 for the new conventions). jqueryUI and bootstrap are provided out of the box now... just set the "ui.provider" key to be either string. NOTE: the base jqueryUI provider file names still need to be made generic... coming in a future minor tweak commit when I get around to it.
