### PR TITLE
quick mods to make auth things testable without requests;

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -8,6 +8,7 @@ var ns = require("./ns"),
 var DEFAULT_AUTHORITY = "guest";
 
 function resolveAuthorities(authorities) {
+  authorities = authorities || [];
   var curr,
       type, 
       outAuths = [];
@@ -161,7 +162,7 @@ var api = exports.api = /** @lends api.prototype */ {
    */
   logoutBySessionId: function(sessionId, cb) {
     if (!sessionId) {
-      cb && cb("Session id is required for loginBySessionId method.");
+      cb && cb("Session id is required for logoutBySessionId method.");
     } else {     
       cache.getItemsWait([
         "feather-server",
@@ -176,17 +177,7 @@ var api = exports.api = /** @lends api.prototype */ {
           server.sessionStore.get(sessionId, function(err, sess) {
             if (err) cb(err); else {
               server.sessionStore.destroy(sessionId, function() {
-                //after destroying the existing session, generate and store a new one, and pass the new sid back to the client
-                var dummyReq = {
-                  headers:{}, 
-                  sessionStore: server.sessionStore,
-                  secret: appOptions.connect.session.secret
-                };
-                server.sessionStore.generate(dummyReq); 
-                server.sessionStore.set(dummyReq.session.id, dummyReq.session);
-                logger.info("new session ID = " + dummyReq.session.id); 
-                dummyReq.sessionID = dummyReq.session.id;            
-                cb(null, dummyReq.session);
+                api.createNewSession(cb);
               });
             }
           });
@@ -194,6 +185,33 @@ var api = exports.api = /** @lends api.prototype */ {
       });
     }
   },
+
+  createNewSession: function(cb) {
+    cache.getItemsWait([
+      "feather-server",
+      "feather-logger",
+      "feather-options"
+    ], function(err, cacheItems) {
+      if (err) cb(err); else {
+        var server = cacheItems["feather-server"],
+          logger = cacheItems["feather-logger"],
+          appOptions = cacheItems["feather-options"];
+  
+        //after destroying the existing session, generate and store a new one, and pass the new sid back to the client
+        var dummyReq = {
+          headers:{}, 
+          sessionStore: server.sessionStore,
+          secret: appOptions.connect.session.secret
+        };
+        server.sessionStore.generate(dummyReq); 
+        server.sessionStore.set(dummyReq.session.id, dummyReq.session);
+        logger.info("new session ID = " + dummyReq.session.id); 
+        dummyReq.sessionID = dummyReq.session.id;            
+        cb(null, dummyReq.session);
+      }
+    });
+  },
+
   /**
    * Not implemented.
    */

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -30,41 +30,16 @@ exports.getMiddleware = function(options, cb) {
         var staticHandler = Connect.static(options.publicRoot);
       }
 
-      //TODO: implement app-overridable method to create the store, and supply a pre-built Couchdb session store implementation
-      //TODO: change this if the result of cache.getItem ever changes to be async (right now it's sync with an async-looking interface due to 
-      //planning for the potential future)
-      cache.getItem("feather-sessionStore", function(err, _sessionStore) {
-        if (!_sessionStore) {
-          _sessionStore = new Connect.session.MemoryStore;
-          cache.setItem("feather-sessionStore", _sessionStore);
-        }
-        options.connect.session.store = _sessionStore;
-      });
-
       var middleware = [
         Connect.cookieParser(options.connect.cookieParser.secret),
         Connect.bodyParser(),
         Connect.session(options.connect.session),
         function(req, res, next) {
-          cache.getItems([
-            "feather-server",
-            "feather-sessionStore"
-          ], function(err, cacheItems) {
-            if (err) next(err); else {
-              var server = cacheItems["feather-server"],
-                sessionStore = cacheItems["feather-sessionStore"];
-
-              if (!server.sessionStore) {
-                server.sessionStore = sessionStore;
-              }
-              
-              if (options.onRequest && typeof(options.onRequest) === 'function') {
-                options.onRequest(feather, req, res, next);
-              }
-              
-              next();
-            }
-          });
+          if (options.onRequest && typeof(options.onRequest) === 'function') {
+            options.onRequest(feather, req, res, next);
+          }
+          
+          next();
         },
         _router,
         //a redirect handler in case the router changes the url

--- a/lib/server.js
+++ b/lib/server.js
@@ -82,6 +82,13 @@ exports.init = function(options, cb) {
       }, 
       createServer: {
         stateStartup: function() {
+
+          //first create the session store
+          //TODO: implement app-overridable method to create the store, and supply a pre-built Couchdb session store implementation
+          var sessionStore = new Connect.session.MemoryStore;
+          cache.setItem("feather-sessionStore", sessionStore);
+          options.connect.session.store = sessionStore;
+
           middleware.getMiddleware(options, function(err, _middleware, _rest) {
             if (err) fsm.fire("error", err); else {
               var mirror = null,
@@ -127,6 +134,7 @@ exports.init = function(options, cb) {
                   }
                 }
 
+                server.sessionStore = sessionStore;
                 fsm.fire("complete", server, mirror);
               };
 


### PR DESCRIPTION
create sessionStore proactively instead of on first request;
added createNewSession method at top level of feather.auth.api;
