### PR TITLE
s3 publisher update.  feather cheat sheet

### DIFF
--- a/api_tester/conf/steve.json
+++ b/api_tester/conf/steve.json
@@ -1,0 +1,41 @@
+{
+  "resources": {
+    "publish": {
+      "consolidate": true,
+      "minify": false,
+      "publisherId": "local",
+      "publishers": [
+        {
+          "id": "local",
+          "config": {
+            "publishLocation": "feather-res-cache"
+          }
+        },
+        {
+          "id": "s3",
+          "config": {
+            "key": "AKIAJ2SZCHHQCYYLLSCQ",
+            "secret": "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",
+            "bucket": "theVolary.feather.test",
+            "acl": "public-read",
+            "publishUri": "http://d2zgz3zrsu7s5n.cloudfront.net"
+          }
+        }
+      ]
+    },
+    "packages": [
+      { 
+        "name":"feather-client-core.js",
+        "consolidate": true,
+        "minify": false,
+        "publisherId": "s3"
+      },
+      {
+        "name": "feather-client-core.css",
+        "consolidate": true,
+        "minify": true,
+        "publisherId": "s3"
+      }
+    ]
+  }
+}

--- a/api_tester/config.json
+++ b/api_tester/config.json
@@ -49,7 +49,8 @@
             "key": "AKIAJ2SZCHHQCYYLLSCQ",
             "secret": "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",
             "bucket": "theVolary.feather.test",
-            "acl": "public-read"
+            "acl": "public-read",
+            "publishUri": "http://d2zgz3zrsu7s5n.cloudfront.net"
           }
         }
       ]

--- a/featherdoc/docs/feather-cheatsheet.markdown
+++ b/featherdoc/docs/feather-cheatsheet.markdown
@@ -1,0 +1,88 @@
+# Feather Cheat Sheet
+
+## App
+
+## Widgets
+
+Create a Widget
+
+`feather create-widget [namespace] widgetName`
+
+### Server-Side
+
+Template
+
+    exports.getWidget = function(feather, cb) {
+      cb(null, {
+	    name: "namespace.widgetName",
+	    path: "widgets/widgetName/",
+	    // prototype: {} goes here
+	  });
+	};
+
+Available Prototype Methods
+
+    prototype: {
+	  onInit: function(options) { },
+	  onRender: function() { },
+	  customServerMethod: feather.Widget.serverMethod(function(arg1, arg2, argN, cb)) {
+	  	cb && cb(err, result);
+	  }
+	}
+
+
+### Client-Side
+
+Available Prototype Methods
+
+    prototype: {
+      onInit: function() { },
+      onReady: function() { }
+    }
+
+Call a server RPC method
+
+    this.server_customServerMethod([arg1, arg2, argN], function(response) {});
+
+Server RPC Method Response Object
+
+    var response = {
+      messageId: String,
+      type: "rpc",
+      err: Object_or_String,
+      success: boolean,
+      result: Object
+    };
+    
+Reference a Child Widget
+
+    this.childWidgetIdFromWidgetTag
+
+Dynamically Load a Widget
+
+    feather.Widget.load({
+      path: "widgets/your_widget_sub_path/",
+      serverOptions: {
+        // contents will be made available to server side of widgets as this.options
+      },
+      clientOptions: {
+        parent: me, // typical default
+        container: me.container, // typical default
+        keepContainerOnDispose: false, // false removes container on dispose.  true just empties it.
+        containerOptions: {
+          containerizer: someObj, // Normally you won't need this
+          title: "",
+          width: 800,
+          height: 600
+        },
+        on: {
+          someEvent: function(sender) {}
+        },
+        once: {
+          someEvent: function() {}
+        },
+        onceState: {a
+          ready: function() {}
+        }
+      }
+    });

--- a/lib/config.json
+++ b/lib/config.json
@@ -108,7 +108,8 @@
             "key": "",
             "secret": "",
             "bucket": "",
-            "acl": "public-read"
+            "acl": "public-read",
+            "publishUri": null
           }
         }
       ]

--- a/lib/s3-resource-publisher.js
+++ b/lib/s3-resource-publisher.js
@@ -33,11 +33,11 @@ module.exports = {
         s3Options.endpoint = options.config.endpoint;
       }
       var s3Client = knox.createClient(s3Options);
-      var baseUrl = s3Client.url('');
+      var baseUrl = options.config.publishUri || s3Client.url('');
 
       var publishResult = {
         files: [],
-        consolidatedUrl: path.join(baseUrl, publisher.id)
+        consolidatedUrl: baseUrl + '/' + publisher.id
       };
       
       _.each(publisher.componentOrder, function(name) {


### PR DESCRIPTION
Added publishUri to s3 resource publisher. Allows specifying a destination URI other than the s3 bucket, for use with CDNs. Also added feather cheatsheet markdown file to the project.
