### PR TITLE
Find fix

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -294,6 +294,7 @@ dataInterface.prototype = {
   find: function(options, cb) {
     
     var cbError, cbResult;
+    var me = this;
     var sem = new Semaphore(function() {
       cb && cb.apply(cb, [cbError, cbResult]);
     });
@@ -322,14 +323,50 @@ dataInterface.prototype = {
         return;
       }
     }
-        
+
+    var fetchPage = function() {
+      me.db.view(options.source, findOptions, function(err, documents) {
+        if (err) { 
+          cbError = formatError(err); 
+        } else {
+          if (documents.length && ! documents[0].value && findOptions.include_docs) {
+            documents = _.map(documents, function(doc) {
+              doc.value = doc.doc;
+              delete doc.doc;
+              return doc;
+            });
+          }
+          if (options.returnValuesOnly) {
+            documents = _.pluck(documents, "value");
+          }
+          if (findOptions.limit) {
+            var limit;
+            if (paginationOn) {
+              limit = Math.min(pagination.pageSize, documents.length);
+            } else {
+              limit = findOptions.limit;
+            }
+            documents = documents.slice(0, limit);
+          }
+          cbError = err;
+          cbResult = {documents:documents, options:options};
+        }
+        sem.execute();
+      });
+    };
+      
+    sem.increment();  
     if (paginationOn) {
 
       findOptions.reduce = false;
+      
       var totalFindOptions = _.extend({}, findOptions);
       totalFindOptions.reduce = true;
+      delete totalFindOptions.include_docs;
       sem.increment();
-      this.db.view(options.source, totalFindOptions, function(err, count) {
+      // NOTE: this doc count assumes the view has a reduce function that returns `values.length`!
+      // If it doesn't, count is set to 0 here and hopefully they choose cachePageBoundaries below so it does get set.
+      me.db.view(options.source, totalFindOptions, function(err, count) {
         if (err) {
           pagination.docCount = 0;
         } else {
@@ -366,57 +403,66 @@ dataInterface.prototype = {
           findOptions.skip = pagination.pageSize * pageNum;
         }
       }
-    } else { // end if pagination is on
 
-    }
+      // Loop through and determine page boundaries..
+      if (prefetchBoundaries) {
 
-    // Fetch data.
-    sem.increment();
-    this.db.view(options.source, findOptions, function(err, documents) {
-      if (err) {
-        cbError = formatError(err);
+        var numRowsInPage = -1,
+            prefetchOptions = _.extend({}, findOptions),
+            runningDocCount = 0;
 
-      } else {
-        if (documents.length && ! documents[0].value && findOptions.include_docs) {
-          documents = _.map(documents, function(doc) {
-            doc.value = doc.doc;
-            delete doc.doc;
-            return doc;
-          });
-        }
-        if (prefetchBoundaries === true) {
-          pagination.pageBoundaries = [];
-          var index = 0;
-          for(index = 0; index < documents.length; index += pagination.pageSize) {
-            pagination.pageBoundaries.push({key: documents[index].key, _id: documents[index].id });
+        prefetchOptions.limit = pagination.pageSize + 1;
+        delete prefetchOptions.include_docs;
+        delete prefetchOptions.endkey;
+        pagination.pageBoundaries = [];
+
+        var prefetchSem = new Semaphore(function() {
+          if (cbError) {
+            sem.execute();
+          } else {
+            pagination.pageCount = pagination.pageBoundaries.length;
+            // Don't set doc count if they specified start or end key.  They'll have to rely on reduce total find.
+            if (! findOptions.startkey && ! findOptions.endkey) pagination.docCount = runningDocCount;
+
+            findOptions.limit = pagination.pageSize;
+            fetchPage();
           }
-          if (options.returnValuesOnly) {
-            documents = _.pluck(documents, "value");
-          }
-          pagination.pageCount = pagination.pageBoundaries.length;
-          pagination.docCount = documents.length;
-          documents = documents.slice(pageNum*pagination.pageSize, Math.min(pagination.pageSize, documents.length));
-          cbResult = {documents:documents, options:options}
+        });
 
-        } else {
-          if (options.returnValuesOnly) {
-            documents = _.pluck(documents, "value");
-          }
-          if (findOptions.limit) {
-            var limit;
-            if (paginationOn) {
-              limit = Math.min(pagination.pageSize, documents.length);
+        prefetchSem.increment();
+        var handlePageBoundary = function(err, documents) {
+          if (err) {
+            cbError = "Error fetching page boundaries: " + util.inspect(err);
+            prefetchSem.execute();
+          } else {
+            numRowsInPage = documents.length > pagination.pageSize ? documents.length-1 : documents.length; // offset for next startkey
+            runningDocCount += numRowsInPage;
+            if (numRowsInPage < pagination.pageSize) {
+              if (documents.length) {
+                // add the last one if there are any at all.
+                pagination.pageBoundaries.push({key: documents[0].key, _id: documents[0].id});
+              }
+              // We're done.  bail.
+              prefetchSem.execute();
             } else {
-              limit = findOptions.limit;
+              pagination.pageBoundaries.push({key: documents[0].key, _id: documents[0].id});
+              prefetchOptions.startkey = documents[documents.length-1].key;
+              prefetchOptions.startkey_docid = documents[documents.length-1].id;
+              me.db.view(options.source, prefetchOptions, handlePageBoundary);
             }
-            documents = documents.slice(0, limit);
+
           }
-          cbError = err;
-          cbResult = {documents:documents, options:options};
         }
+
+        me.db.view(options.source, prefetchOptions, handlePageBoundary);
+      } else { // no prefetch needed.
+        fetchPage();
       }
-      sem.execute();
-    });
+
+    } else { // pagination is OFF
+
+      fetchPage();      
+    }
   },
   findNextPage: function(options, cb) {
     options = offsetPage(options, 1);

--- a/test/data/pagination.js
+++ b/test/data/pagination.js
@@ -67,10 +67,31 @@ describe('pagination tests', function(done) {
         });
       }
     });
+    // request.put({ uri: 'http://admin:password@localhost:5984/' + dbOpts.dbName + "_clean" }, function(err, res, body) {
+    //   if (err || res.statusCode !== 201) {
+    //     console.error("Error creating database: " + err + "; status " + (res ? res.statusCode : "unknown"));
+    //     done();
+    //     throw new Error("Could not create database " + err + "; status " + (res ? res.statusCode : "unknown"));
+    //   } else {
+    //     request({
+    //       uri: 'http://admin:password@localhost:5984/' + dbOpts.dbName + "_clean/_bulk_docs",
+    //       json: { docs: testDocs },
+    //       method: "POST"
+    //     }, function(postErr, postRes, postBody) {
+    //       if (postErr || postRes.statusCode !== 201) {
+    //         done();
+    //         throw new Error("Couldn't populate db.");
+    //       } else {
+    //         console.info("Database populated.");
+    //         db = new DataInterface(dbOpts);
+    //         done();
+    //       }
+    //     });
+    //   }
+    // });
   });
 
   after(function(done) {
-    console.info("In after");
     _.each(testDocs, function(doc) {
       doc._deleted = true;
     });
@@ -129,7 +150,9 @@ describe('pagination tests', function(done) {
         pageNumber: 2
       }
     }, function(err, result) {
-      if (err) done(err); else {
+      if (err) {
+        done(err); 
+      } else {
         result.documents.length.should.equal(3);
         result.options.pagination.pageBoundaries.length.should.equal(5);
         result.documents[0].name.should.equal('Festerhide Boar');
@@ -159,7 +182,7 @@ describe('pagination tests', function(done) {
         result.documents[0].name.should.equal('Festerhide Boar');
         result.documents[2].name.should.equal('Griffin Rider');
         should.exist(result.options.pagination.docCount);
-        result.options.pagination.docCount.should.equal(5);
+        result.options.pagination.docCount.should.equal(5, "doc count");
         done();
       }
     });


### PR DESCRIPTION
Find method now uses multiple http requests to cache page boundary data to avoid large in-memory data sets.
