### PR TITLE
No 404 for missing css files

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -160,7 +160,7 @@ exports.getMiddleware = function(options, cb) {
               logger.info({category:'http.server', message: '404 error for url ' + req.url});
               //allow for .feather.html based 404 pages by doing redirect (so middleware stack is re-applied)
               //if there's no css file don't error out - they aren't required for widgets
-              if (req.url !== (options.connect['404'] || "/404.html" || req.url.match(/css$/))) {
+              if (req.url !== (options.connect['404'] || "/404.html" || req.url.match(/\.css$/))) {
                 req.url = options.connect['404'] || "/404.html";
                 //do the redirect
                 res.statusCode = 303;


### PR DESCRIPTION
Don't serve a 404 page if we don't have a css file for a widget, since a 1:1 widget to stylesheet ratio leads to issues in IE when we start using dynamic widgets (it also goes against the concept of **cascading** style sheets)
