### PR TITLE
Adjusted feather.rest calls so you can pass in (options, cb) and include...

### DIFF
--- a/lib/feather-client/restProxy.js
+++ b/lib/feather-client/restProxy.js
@@ -7,6 +7,21 @@
       feather.rest[api.name] = {};
       _.each(api.methods, function(method) {
         feather.rest[api.name][method.name] = function(path, data, cb) {
+          var options = null;
+
+          // Freakish hack to allow users to pass in standard function call style of func(options, cb).  
+          //   This allows us flexibility for passing more options to $.ajax in the future.
+          if (typeof path === "object" && typeof data === "function") {
+            options = path;
+            cb = data;
+            data = null;
+          } else {
+            options = {
+              path: path,
+              data: data
+            };
+          }
+
           if (typeof data === "function") {
             cb = data;
             data = null;
@@ -19,10 +34,11 @@
           }
 
           $.ajax({
-            url: encodeURI("/_rest/" + api.name + decodeURI(path)),
-            data: (typeof data === "undefined" || data === null) ? null : JSON.stringify(data),
+            url: encodeURI("/_rest/" + api.name + decodeURI(options.path)),
+            data: (typeof options.data === "undefined" || options.data === null) ? null : JSON.stringify(options.data),
             type: method.verb,
             dataType: "json",
+            headers: options.headers || null,
             contentType: contentType,
             success: function(result) {
               cb && cb({


### PR DESCRIPTION
... http headers.
